### PR TITLE
Add ARM 32 bit dockerfile for Raspberry Pi

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,67 @@
+FROM arm32v7/ubuntu:18.04
+MAINTAINER Fabian Stäber, fabian@fstab.de
+
+# Edit the LAST_UPDATE variable to force re-run of 'apt-get update' when building
+# the Docker image
+ENV LAST_UPDATE=2018-05-31
+
+RUN apt-get update && apt-get upgrade -y
+
+WORKDIR /root
+
+#------------------------------------------------------------------------------
+# Basic tools
+#------------------------------------------------------------------------------
+
+RUN apt-get install -y \
+    autoconf \
+    build-essential \
+    curl \
+    git \
+    wget \
+    vim
+
+#------------------------------------------------------------------------------
+# Go development
+#------------------------------------------------------------------------------
+
+# Install golang manually, so we get the latest version.
+
+RUN cd /usr/local && \
+    curl -sLO https://dl.google.com/go/go1.10.3.linux-armv6l.tar.gz && \
+    tar xfz go1.10.3.linux-armv6l.tar.gz && \
+    rm go1.10.3.linux-armv6l.tar.gz && \
+    cd /root && \
+    mkdir -p go/bin go/pkg
+
+ENV GOROOT="/usr/local/go" \
+    GOPATH="/root/go"
+ENV PATH="${GOROOT}/bin:${PATH}"
+ENV PATH="${GOPATH}/bin:${PATH}"
+
+#------------------------------------------------------------------------------
+# Create a statically linked Oniguruma library for Linux arm32
+#------------------------------------------------------------------------------
+
+# This will create /usr/local/lib/libonig.a
+
+RUN cd /tmp && \
+    curl -sLO https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz && \
+    tar xfz onig-5.9.6.tar.gz && \
+    rm onig-5.9.6.tar.gz && \
+    cd /tmp/onig-5.9.6 && \
+    cp /usr/share/misc/config.guess . && \
+    ./configure && \
+    make && \
+    make install && \
+    cd /root && \
+    rm -r /tmp/onig-5.9.6
+
+#------------------------------------------------------------------------------
+# Create compile scripts
+#------------------------------------------------------------------------------
+
+COPY check-if-gopath-available.sh compile-linux.sh /root/
+
+CMD /root/check-if-gopath-available.sh && echo "Type 'ls' to see the available compile scripts." && exec /bin/bash
+


### PR DESCRIPTION
First of all, thanks for grok_exporter!  I use this all the time in my day job.  I also wanted to use it for a hobby project with my Raspberry Pi.  So I followed the examples from the other dockerfiles in this repo, and added a new dockerfile based on a 32 bit ARM base image.  

The differences are:

* `arm32v7/ubuntu:18.04` image
* `https://dl.google.com/go/go1.10.3.linux-armv6l.tar.gz` tarball.  Note that there is no armv7 go release, but they say that v6 works fine.

I tested this out on my raspberry pis and it works great!

Corresponding PR in the grok_exporter repo: https://github.com/fstab/grok_exporter/pull/41